### PR TITLE
Revert "adsb.im save time on firstboot"

### DIFF
--- a/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
+++ b/rootfs/var/lib/dietpi/services/dietpi-firstboot.bash
@@ -352,9 +352,8 @@ _EOF_
 		# - Configure enabled interfaces now, /etc/network/interfaces will be effective from next boot on
 		#	Failsafe: Bring up Ethernet, whenever WiFi is disabled or fails to be configured, e.g. due to wrong credentials
 		# shellcheck disable=SC2015
-		# adsb.im: calling ifup here is unnecessary, once dietpi-firstboot.service is done, networking.service will bring up the configured interfaces
-		#(( $wifi_enabled )) && ifup "$iface_wlan"
-		#(( $ethernet_enabled )) && ifup "$iface_eth"
+		(( $wifi_enabled )) && ifup "$iface_wlan"
+		(( $ethernet_enabled )) && ifup "$iface_eth"
 
 		# - Boot wait for network
 		/boot/dietpi/func/dietpi-set_software boot_wait_for_network "$(( ! $(grep -cm1 '^[[:blank:]]*AUTO_SETUP_BOOT_WAIT_FOR_NETWORK=0' /boot/dietpi.txt) ))"


### PR DESCRIPTION
This reverts commit cdce5ce8c9eef392dbd6b9174aae24f023387afb.

That commit probably broke dietpi ethernet firstboot. Not good, revert it.

